### PR TITLE
Add datasette-dashboards to plugin repos list

### DIFF
--- a/plugin_repos.yml
+++ b/plugin_repos.yml
@@ -70,3 +70,4 @@
 - simonw/datasette-x-forwarded-host
 - simonw/datasette-verify
 - simonw/datasette-template-request
+- rclement/datasette-dashboards


### PR DESCRIPTION
Add the `rclement/datasette-dashboards` plugin to the Datasette plugin repositories list.