### PR TITLE
Add datasette-query-files to plugin repos

### DIFF
--- a/plugin_repos.yml
+++ b/plugin_repos.yml
@@ -88,3 +88,4 @@
 - simonw/datasette-copy-to-memory
 - simonw/datasette-upload-dbs
 - simonw/datasette-socrata
+- eyeseast/datasette-query-files


### PR DESCRIPTION
Allows writing canned queries as plain SQL files, with optional JSON/YAML metadata.