### PR TITLE
proper nesting of <div>s on index page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -63,24 +63,24 @@
         <h2><a href="/for/exploratory-analysis">Exploratory data analysis</a></h2>
         <p>Import data from CSVs, JSON, database connections and more. Datasette will automatically show you patterns in your data and help you share your findings with your colleagues.</p>
       </div>
-    </div>
-    <div class="card">
-      <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10" viewBox="0 0 24 24">
-        <polyline points="16 16 12 12 8 16"></polyline>
-        <line x1="12" y1="12" x2="12" y2="21"></line>
-        <path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"></path>
-        <polyline points="16 16 12 12 8 16"></polyline>
-      </svg>
-      <h2><a href="/for/publishing-data">Instant data publishing</a></h2>
-      <p><code>datasette publish</code> lets you instantly publish your data to hosting providers like Google Cloud Run, Heroku or Vercel.</p>
-    </div>
-    <div class="card">
-      <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10" viewBox="0 0 24 24">
-        <polyline points="16 18 22 12 16 6"></polyline>
-        <polyline points="8 6 2 12 8 18"></polyline>
-      </svg>
-      <h2><a href="/for/rapid-prototyping">Rapid prototyping</a></h2>
-      <p>Spin up a JSON API for any data in minutes. Use it to prototype and prove your ideas without building a custom backend.</p>
+      <div class="card">
+        <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10" viewBox="0 0 24 24">
+          <polyline points="16 16 12 12 8 16"></polyline>
+          <line x1="12" y1="12" x2="12" y2="21"></line>
+          <path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"></path>
+          <polyline points="16 16 12 12 8 16"></polyline>
+        </svg>
+        <h2><a href="/for/publishing-data">Instant data publishing</a></h2>
+        <p><code>datasette publish</code> lets you instantly publish your data to hosting providers like Google Cloud Run, Heroku or Vercel.</p>
+      </div>
+      <div class="card">
+        <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10" viewBox="0 0 24 24">
+          <polyline points="16 18 22 12 16 6"></polyline>
+          <polyline points="8 6 2 12 8 18"></polyline>
+        </svg>
+        <h2><a href="/for/rapid-prototyping">Rapid prototyping</a></h2>
+        <p>Spin up a JSON API for any data in minutes. Use it to prototype and prove your ideas without building a custom backend.</p>
+      </div>
     </div>
     <div style="clear: both; padding-top: 2em;" class="two-col-wrapper">
       <div class="two-col-column">


### PR DESCRIPTION
All three `class="card"` divs should be wrapped by the `class="use-cases"` div. 

Just something I noticed while inspecting the site.