### PR TITLE
Added mastodon-to-sqlite to the list of tools

### DIFF
--- a/tool_repos.yml
+++ b/tool_repos.yml
@@ -38,3 +38,4 @@
 - simonw/pypi-to-sqlite
 - simonw/s3-ocr
 - simonw/sqlite-comprehend
+- myles/mastodon-to-sqlite


### PR DESCRIPTION
Added a dogsheep library I wrote to [save data from Mastodon to SQLite database](https://github.com/myles/mastodon-to-sqlite). Hope that’s okay, it’s had its first release on PyPI.