### PR TITLE
plugins: expose pypi version as tag_name again

### DIFF
--- a/build_directory.py
+++ b/build_directory.py
@@ -205,7 +205,7 @@ select
   users.login as owner,
   repos.description as description,
   repos.stargazers_count,
-  pypi_versions.name,
+  pypi_versions.name as tag_name,
   max(pypi_releases.upload_time) as latest_release_at,
   repos.created_at as created_at,
   datasette_repos.openGraphImageUrl,


### PR DESCRIPTION
ee3fc29f95cf04d9ef98ec8d732ce4ce78b1926c changed the output of the python package version column name from `tag_name` to `name:1`, which broke the plugin update check in datasette-app-support.
This PR should help with the hang issue of Datasette Desktop, see https://github.com/simonw/datasette-app/issues/153