### PR TITLE
Add datasette-ml to the plugin repos list

### DIFF
--- a/plugin_repos.yml
+++ b/plugin_repos.yml
@@ -352,3 +352,6 @@
 - repo: simonw/datasette-chatgpt-plugin
   tags:
   - API
+- repo: rclement/datasette-ml
+  tags:
+  - Machine Learning


### PR DESCRIPTION
Adds the [`datasette-ml`](https://github.com/rclement/datasette-ml) plugin to the repositories list. This plugin allows to train, deploy and run predictions from machine learning models directly from Datasette, leveraging [`sqlite-ml`](https://github.com/rclement/sqlite-ml/).