### PR TITLE
Add mastodon-to-sqlite to tools

### DIFF
--- a/tool_repos.yml
+++ b/tool_repos.yml
@@ -1,184 +1,188 @@
 - repo: simonw/csvs-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/sqlite-utils
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/django-sql-dashboard
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/db-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/twitter-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/csv-diff
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/github-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/dogsheep-photos
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/healthkit-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/dogsheep-beta
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/google-takeout-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/pocket-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/swarm-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/yaml-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/airtable-export
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/markdown-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/geojson-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/dbf-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/sqlite-transform
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/hacker-news-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/evernote-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/sqlite-diffable
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/sqlite-generate
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/shapefile-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/genome-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/download-tiles
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/tableau-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/fec-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/inaturalist-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/sphinx-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/datasette-clone
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/datasette-app
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/git-history
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/s3-credentials
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/google-drive-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/shot-scraper
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: eyeseast/geocode-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/pypi-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/s3-ocr
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/sqlite-comprehend
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/json-to-files
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/openai-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: dogsheep/apple-notes-to-sqlite
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/llm
   tags:
-  - Untagged
+    - Untagged
   extra_search: "ai chatgpt openai"
 - repo: simonw/strip-tags
   tags:
-  - Untagged
+    - Untagged
   extra_search: ""
 - repo: simonw/ttok
   tags:
-  - Untagged
+    - Untagged
+  extra_search: ""
+- repo: myles/mastodon-to-sqlite
+  tags:
+    - Untagged
   extra_search: ""

--- a/tool_repos.yml
+++ b/tool_repos.yml
@@ -183,4 +183,6 @@
   - Untagged
   extra_search: ""
 - repo: myles/mastodon-to-sqlite
-
+  tags:
+  - Untagged
+  extra_search: ""

--- a/tool_repos.yml
+++ b/tool_repos.yml
@@ -1,188 +1,186 @@
 - repo: simonw/csvs-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/sqlite-utils
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/django-sql-dashboard
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/db-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/twitter-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/csv-diff
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/github-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/dogsheep-photos
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/healthkit-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/dogsheep-beta
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/google-takeout-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/pocket-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/swarm-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/yaml-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/airtable-export
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/markdown-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/geojson-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/dbf-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/sqlite-transform
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/hacker-news-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/evernote-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/sqlite-diffable
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/sqlite-generate
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/shapefile-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/genome-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/download-tiles
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/tableau-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/fec-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/inaturalist-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/sphinx-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/datasette-clone
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/datasette-app
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/git-history
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/s3-credentials
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/google-drive-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/shot-scraper
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: eyeseast/geocode-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/pypi-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/s3-ocr
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/sqlite-comprehend
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/json-to-files
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/openai-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: dogsheep/apple-notes-to-sqlite
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/llm
   tags:
-    - Untagged
+  - Untagged
   extra_search: "ai chatgpt openai"
 - repo: simonw/strip-tags
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: simonw/ttok
   tags:
-    - Untagged
+  - Untagged
   extra_search: ""
 - repo: myles/mastodon-to-sqlite
-  tags:
-    - Untagged
-  extra_search: ""
+


### PR DESCRIPTION
This adds the very helpful [mastodon-to-sqlite](https://github.com/myles/mastodon-to-sqlite) tool written by @myles to the list of datasette/sqlite tools.