### PR TITLE
Add codemicro/datasette-auth-headers to plugin list

### DIFF
--- a/plugin_repos.yml
+++ b/plugin_repos.yml
@@ -493,3 +493,6 @@
 - repo: datasette/datasette-checkbox
   tags:
   - UI
+- repo: codemicro/datasette-auth-headers
+  tags:
+  - Authentication


### PR DESCRIPTION
Threw this together quickly since I couldn't find anything similar that implemented the forward auth/proxy authentication methods supported by the likes of [Authentik](https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/) and [Authelia](https://www.authelia.com/reference/guides/proxy-authorization/) (two examples of selfhosted identity platforms):

![image](https://github.com/user-attachments/assets/ffe760e2-1798-4cb1-aa70-d831610360b2)

My plugin just implements the bit in the "service" column of this diagram.