### PR TITLE
Add datasette-google-analytics plugin

### DIFF
--- a/plugin_repos.yml
+++ b/plugin_repos.yml
@@ -493,3 +493,6 @@
 - repo: datasette/datasette-checkbox
   tags:
   - UI
+- repo: ngshiheng/datasette-google-analytics
+  tags:
+  - Analytics


### PR DESCRIPTION
hey! I would like to list my plugin that adds Google Analytics tracking code to Datasette instances. I personally use it for my own Datasette deployments, and I thought others might find it useful as well.

The source code is available at: https://github.com/ngshiheng/datasette-google-analytics  

Usage examples, you can see: https://github.com/search?q=datasette-google-analytics+language%3AJSON&type=code&l=JSON

Thanks!