### PR TITLE
Add claude-code-to-sqlite to tools directory

### DIFF
--- a/tool_repos.yml
+++ b/tool_repos.yml
@@ -182,3 +182,7 @@
   tags:
   - Untagged
   extra_search: ""
+- repo: hockinghills/claude-code-to-sqlite
+  tags:
+  - Untagged
+  extra_search: "claude anthropic ai sessions"


### PR DESCRIPTION
Adds [claude-code-to-sqlite](https://github.com/hockinghills/claude-code-to-sqlite) to the tools directory.

It imports Claude Code CLI session transcripts, browser export files, and claude.ai web export ZIPs into a SQLite database for exploration with Datasette. Available on [PyPI](https://pypi.org/project/claude-code-to-sqlite/).