### PR TITLE
Two-column nav on mobile for inner pages

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -116,7 +116,11 @@ body.page header {
         padding-right: 1em;
     }
     body.page nav ul {
-        display: block;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-auto-flow: column;
+        grid-template-rows: repeat(3, auto);
+        gap: 0 1em;
     }
 }
 


### PR DESCRIPTION
> <img width="1320" height="545" alt="IMG_4884" src="https://github.com/user-attachments/assets/da16106f-ea51-4ea6-93cd-235477ab9038" />
>
> On mobile I want this to be two columns not one

https://claude.ai/code/session_011AKi8xt6CdbpDkj8KQQB27