### PR TITLE
Hide empty Tutorials <li> on narrow screens

### DIFF
--- a/templates/_nav_links.html
+++ b/templates/_nav_links.html
@@ -1,7 +1,7 @@
 <ul>
     <li><a href="/for">Uses</a></li>
     <li><a href="https://docs.datasette.io/en/stable/"><span class="hide-on-narrow">Documentation</span> <span class="show-on-narrow">Docs</span></a></li>
-    <li><a href="/tutorials"><span class="hide-on-narrow">Tutorials</span></a></li>
+    <li class="hide-on-narrow"><a href="/tutorials">Tutorials</a></li>
     <li><a href="/examples">Examples</a></li>
     <li><a href="/plugins">Plugins</a></li>
     <li><a href="/tools">Tools</a></li>


### PR DESCRIPTION
> <img width="1320" height="324" alt="IMG_4886" src="https://github.com/user-attachments/assets/4b1c0799-ad3d-488e-bd76-dda3295319f8" />
> 
> Consider most recent commit, it looks like this - I want two columns

The Tutorials link had only a hide-on-narrow span, so on mobile the `<li>`
rendered empty but still occupied a grid cell — pushing the 2-column nav
grid into 3 columns.

https://claude.ai/code/session_01NkBNjCLUQEH2sWeQcsbmCg