### PR TITLE
news.yaml: add CalcFi Open Data Datasette deployment

### DIFF
--- a/news.yaml
+++ b/news.yaml
@@ -1,3 +1,6 @@
+- date: 2026-05-22
+  body: |-
+    [CalcFi Open Data](https://calcfi-open-data.vercel.app/) is a new public Datasette deployment serving 117,956 observations across 34 free CC-BY financial and macroeconomic time series mirrored verbatim from primary sources (FRED, BLS, Freddie Mac, US Treasury, BEA, World Bank, Federal Reserve, FDIC). Five pre-built named queries cover series coverage, latest-per-series, and a live mortgage vs Treasury weekly spread. The same data is also available through a [Python client](https://pypi.org/project/calcfidata/), [Anaconda](https://anaconda.org/jeresalmisto/calcfidata), [Read the Docs](https://calcfidata.readthedocs.io/), [Google BigQuery Public Datasets](https://console.cloud.google.com/bigquery/analytics-hub/discovery/projects/1099067620437/locations/us/dataExchanges/calcfi_open_data_exchange/listings/calcfi_open_data), and a [Hugging Face dataset](https://huggingface.co/datasets/iizy/calcfi-open-data), with five permanent DOIs ([Figshare](https://doi.org/10.6084/m9.figshare.32332290), Zenodo, OSF, Kaggle, Mendeley).
 - date: 2026-04-19
   body: |-
     Here's a new TIL on [using SQL functions in Google Sheets to fetch data from Datasette](https://til.simonwillison.net/google-sheets/datasette-sql).


### PR DESCRIPTION
Adds a news.yaml entry announcing the [CalcFi Open Data](https://calcfi-open-data.vercel.app/) Datasette deployment.

**About:** 117,956 observations across 34 free CC-BY financial and macroeconomic time series, mirrored verbatim from primary sources (Federal Reserve Bank of St. Louis FRED, US Bureau of Labor Statistics BLS, Freddie Mac, US Treasury, BEA, World Bank, Federal Reserve, FDIC, EIA). Five pre-built named queries: series_coverage, latest_per_series, mortgage_treasury_spread, inflation_cpi_vs_pce, yield_curve_2s10s.

**Live SQL:** https://calcfi-open-data.vercel.app/ — JSON + CSV export per query.

**Companion surfaces:** Python client `pip install calcfidata` ([PyPI](https://pypi.org/project/calcfidata/) · [Anaconda](https://anaconda.org/jeresalmisto/calcfidata)), Go client on [pkg.go.dev](https://pkg.go.dev/gitlab.com/jere.salmisto/calcfi-open-data/go), R client under CRAN review, [BigQuery Public Datasets](https://console.cloud.google.com/bigquery/analytics-hub/discovery/projects/1099067620437/locations/us/dataExchanges/calcfi_open_data_exchange/listings/calcfi_open_data), [Read the Docs](https://calcfidata.readthedocs.io/), 5 permanent DOIs ([Figshare](https://doi.org/10.6084/m9.figshare.32332290), Zenodo, OSF, Kaggle, Mendeley).

**License:** Code MIT, data CC BY 4.0.

**Methodology paper** under review at SSRN.

Happy to adjust the news entry to whatever style/length fits the editorial voice — also fine to close if the project doesn't fit news.yaml's scope (perhaps a /uses or a tools entry would be more appropriate; let me know and I'll re-open in the right place).
