### PR TITLE
Add max-width: 100% to images on the blog

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -282,3 +282,8 @@ body.blog-page .blog-post-date {
 .blog-post-teaser p {
     margin-top: 0;
 }
+
+body.blog-page .content img {
+    max-width: 100%;
+    height: auto;
+}


### PR DESCRIPTION
Blog post images could overflow the content area on narrow viewports.
Constrain them to the content width while preserving aspect ratio.

For https://datasette.io/blog/2026/sql-write-queries/