### PR TITLE
Allow unsafe HTML in feed canned query for datasette-atom

### DIFF
--- a/datasette.yml
+++ b/datasette.yml
@@ -50,6 +50,12 @@ databases:
       global-power-plants:
         facets: ["country_long", "owner", "primary_fuel"]
 plugins:
+  datasette-atom:
+    # Without this, bleach escapes the Pygments <div>/<span> markup in
+    # blog post code blocks and feed readers show it as literal text
+    allow_unsafe_html_in_canned_queries:
+      content:
+        - feed
   dogsheep-beta:
     database: dogsheep-index
     config_file: templates/dogsheep-beta.yml


### PR DESCRIPTION
The codehilite markdown extension wraps code blocks in Pygments
`<div>/<span>` markup, which datasette-atom's bleach allowlist escapes
into literal visible text in feed readers like NetNewsWire.

https://claude.ai/code/session_01MABcput8ynJhGpvkg21gqc