### PR TITLE
Fix mobile horizontal scroll from long inline code in news/releases

### DIFF
--- a/blog-content/api-extras.md
+++ b/blog-content/api-extras.md
@@ -11,11 +11,11 @@ The key problem with the 0.x API is its verbosity: Datasette usually returns mor
 
 The `?_extra=` mechanism, first introduced for tables [in Datasette 1.0a3](https://docs.datasette.io/en/latest/changelog.html#a3-2023-08-09), is designed to address that. 1.0a33 extends that pattern to rows and queries. Quoting the [1.0a33 release notes](https://docs.datasette.io/en/latest/changelog.html#a33-2026-06-11):
 
-> **`?_extra=` support for row and query pages**
+> **`?_extra=` support for row and query pages**
 > 
-> Row and query JSON pages now support the same `?_extra=` mechanism as table pages. Row pages can request extras such as `foreign_key_tables`, `query`, `metadata` and `database_color`; arbitrary SQL and stored query pages can request extras such as `columns`, `query`, `metadata` and `private`. The implementation was refactored into a registry of extra classes shared by all three page types.
+> Row and query JSON pages now support the same `?_extra=` mechanism as table pages. Row pages can request extras such as `foreign_key_tables`, `query`, `metadata` and `database_color`; arbitrary SQL and stored query pages can request extras such as `columns`, `query`, `metadata` and `private`. The implementation was refactored into a registry of extra classes shared by all three page types.
 >
-> New generated reference documentation describes every `?_extra=` parameter available on table, row and query JSON pages, with example output captured from a live Datasette instance at documentation build time. See [Expanding JSON responses](https://docs.datasette.io/en/latest/json_api.html#json-api-extra) for the full list.
+> New generated reference documentation describes every `?_extra=` parameter available on table, row and query JSON pages, with example output captured from a live Datasette instance at documentation build time. See [Expanding JSON responses](https://docs.datasette.io/en/latest/json_api.html#json-api-extra) for the full list.
 
 The minimal default response for a table page such as `/fixtures/facetable.json` in Datasette 1.0 [starts like this](https://latest.datasette.io/fixtures/facetable.json):
 
@@ -116,7 +116,7 @@ Which returns this JSON, with each requested extra corresponding to a key in the
 }
 ```
 
-You can explore the full set of available extras in the [Datasette extras API explorer tool](https://tools.simonwillison.net/datasette-extras-explorer):
+You can explore the full set of available extras in the [Datasette extras API explorer tool](https://tools.simonwillison.net/datasette-extras-explorer):
 
 ![Screenshot of a web application titled "Datasette extras explorer". A URL input field contains https://latest.datasette.io/fixtures/facetable.json with a teal Explore button next to it. Below, a left panel labeled EXTRAS (30) lists checkboxes: all_columns - All columns in the table, regardless of _col/_nocol filtering; column_types - Column type assignments for this table; columns (checked) - Column names returned by this query; count - Total count of rows matching these filters; count_sql - SQL query used to calculate the total count; custom_table_templates - Custom template names considered for this table; database - Database name; database_color - Color assigned to the database. A right panel labeled RESPONSE shows GET /fixtures/fac… with Copy JSON and Copy URL buttons, then a dark JSON viewer showing 200 - 9.9 KB - 114ms and JSON: "ok": true, "next": null, "columns": (highlighted array) "pk", "created", "planet_int", "on_earth", "state", "_city_id", "_neighborhood", "tags", "complex_array", "distinct_some_null", "n", "rows": list of objects.](https://datasette.io/static/blog/2026/extras-explorer.png)
 

--- a/build_directory.py
+++ b/build_directory.py
@@ -181,6 +181,16 @@ def cli(
             db_filename, list(repos_to_fetch_releases_for), auth="auth.json"
         )
 
+    # Release notes sometimes contain non-breaking spaces (U+00A0) around inline
+    # code and links, which render as &nbsp; and cannot line-break - causing
+    # horizontal overflow on narrow viewports. Normalize them to regular spaces.
+    if db["releases"].exists():
+        with db.conn:
+            db.execute(
+                "update releases set body = replace(body, char(160), ' ') "
+                "where body like '%' || char(160) || '%'"
+            )
+
     # Fetch details for any repos that have changed since last time
     repos_to_fetch = []
     for row in db["datasette_repos"].rows:

--- a/static/site.css
+++ b/static/site.css
@@ -220,17 +220,6 @@ span.by {
 .two-col-column:first-of-type {
     padding-right: 1em;
 }
-/* News and release-note markdown can contain long inline <code> tokens and
-   links (often joined by &nbsp;, which cannot line-break). On narrow/mobile
-   viewports these overflow the column and cause a horizontal scrollbar, so
-   allow them to wrap. */
-.two-col-column {
-    overflow-wrap: break-word;
-}
-.two-col-column code,
-.two-col-column a {
-    overflow-wrap: anywhere;
-}
 
 .github-corner:hover .octo-arm{
     animation:octocat-wave 560ms ease-in-out

--- a/static/site.css
+++ b/static/site.css
@@ -220,6 +220,17 @@ span.by {
 .two-col-column:first-of-type {
     padding-right: 1em;
 }
+/* News and release-note markdown can contain long inline <code> tokens and
+   links (often joined by &nbsp;, which cannot line-break). On narrow/mobile
+   viewports these overflow the column and cause a horizontal scrollbar, so
+   allow them to wrap. */
+.two-col-column {
+    overflow-wrap: break-word;
+}
+.two-col-column code,
+.two-col-column a {
+    overflow-wrap: anywhere;
+}
 
 .github-corner:hover .octo-arm{
     animation:octocat-wave 560ms ease-in-out


### PR DESCRIPTION
Strip `&nbsp` (actually U+00A0 / char(160)) from imported release notes.

https://claude.ai/code/session_017U5ZCTwEptaNsPNJvZKbM4